### PR TITLE
Upgrade to Neo4j-OGM 3.2.1

### DIFF
--- a/bitcoin-neo4j/project-back-end/pom.xml
+++ b/bitcoin-neo4j/project-back-end/pom.xml
@@ -45,7 +45,7 @@
         <!-- https://mvnrepository.com/artifact/org.neo4j/neo4j -->
         <neo4j.version>3.5.11</neo4j.version>
         <!-- https://mvnrepository.com/artifact/org.neo4j/neo4j-ogm-bolt-driver -->
-        <neo4j-driver.version>3.1.14</neo4j-driver.version>
+        <neo4j-ogm.version>3.2.1</neo4j-ogm.version>
         <!-- https://mvnrepository.com/artifact/org.mapstruct/mapstruct -->
         <mapstruct.version>1.3.0.Final</mapstruct.version>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
@@ -106,13 +106,11 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-embedded-driver</artifactId>
-            <version>${neo4j-driver.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-bolt-driver</artifactId>
-            <version>${neo4j-driver.version}</version>
         </dependency>
         <!-- Java utils -->
         <dependency>


### PR DESCRIPTION
Hi,

thanks for opening https://github.com/neo4j/neo4j-ogm/issues/663 on Neo4j-OGM.

You are using a custom version property in your `pom.xml` (`neo4j-driver.version`). 
Spring Boot already does version management for your, see [Dependency Management](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using-boot-dependency-management) and the list of all managed versions inside the [BOM](https://github.com/spring-projects/spring-boot/blob/2.1.x/spring-boot-project/spring-boot-dependencies/pom.xml#L144).

To overwrite one of those versions, you have to use the same name.

What happens when you use your custom name and dependency declaration is the following
- OGM bolt is now 3.2.1
- OGM embedded is now 3.2.1
- OGM core is still 3.1.14

So the "trick" here is that you have to use the official properties. This is what I did in this PR. I'm gonna close the ticket on our side, as things work as expected here when all dependencies match.

Having said all that: I see that you have a lot of tests in your project, they all went green. This is great. While we really took care to make Neo4j-OGM 3.2.1 work with Spring Boot 2.1.8 and especially Spring Data Lovelace, they might be issues as Neo4j-OGM 3.2.1 is the underlying foundation for Spring Data Moore, which has been released yesterday. To use that, you'll have to declare `spring-data-releasetrain.version` property with a value of `Moore-RELEASE`. However, I think that `Moore` is not compatible with Boot 2.1.8.

And last but not least, I noticed that you called your property "driver". 
The terminology of the modules of OGM is far from ideal, I wrote an explanation here https://michael-simons.github.io/neo4j-sdn-ogm-tips/what_are_the_building_blocks_of_sdn_and_ogm.html